### PR TITLE
Updated module configuration example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ import { AppComponent } from './app';
 
 @NgModule({
   imports: [
-    IntercomModule.forRoot(YOUR_APP_ID)
+    IntercomModule.forRoot({
+      app_id: <app_id>
+    })
   ]
 })
 export class AppModule{}


### PR DESCRIPTION
The documentation implied that you pass `YOUR_APP_ID` as a string directly to forRoot, which was incorrect. Updated to be more specific.