### PR TITLE
Fixed issue with circular dependency leading to error described in #14

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "Angular"
   ],
   "scripts": {
-    "prebublish": "ngc -p ./tsconfig.json"
+    "preinstall": "ngc -p ./tsconfig.json"
   },
   "author": "scott-wyatt",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "Angular"
   ],
   "scripts": {
-    "build": "ngc -p ./tsconfig.json"
+    "prebublish": "ngc -p ./tsconfig.json"
   },
   "author": "scott-wyatt",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "Angular"
   ],
   "scripts": {
-    "preinstall": "ngc -p ./tsconfig.json"
+    "build": "ngc -p ./tsconfig.json"
   },
   "author": "scott-wyatt",
   "contributors": [

--- a/src/intercom.module.ts
+++ b/src/intercom.module.ts
@@ -1,16 +1,14 @@
 import { CommonModule } from '@angular/common';
-import { InjectionToken, ModuleWithProviders, NgModule } from '@angular/core';
+import { ModuleWithProviders, NgModule } from '@angular/core';
 import { IntercomHideDirective } from './directives/hide.directive';
 import { IntercomShowMessagesDirective } from './directives/show-messages.directive';
 import { IntercomShowNewMessageDirective } from './directives/show-new-message.directive';
 import { IntercomShowDirective } from './directives/show.directive';
 import { IntercomShutdownDirective } from './directives/shutdown.directive';
 import { IntercomTrackEventDirective } from './directives/track-event.directive';
-import { Intercom } from './providers/intercom';
+import { CONFIG, Intercom } from './providers/intercom';
 import { IntercomConfig } from './types/intercom-config';
 import { loadIntercom } from './util/load-intercom';
-
-export const CONFIG = new InjectionToken('CONFIG');
 
 @NgModule({
     imports: [CommonModule],

--- a/src/providers/intercom.ts
+++ b/src/providers/intercom.ts
@@ -1,7 +1,9 @@
-import { Injectable, Inject } from '@angular/core';
-import { CONFIG } from '../intercom.module';
+import { Injectable, Inject, InjectionToken } from '@angular/core';
 import { IntercomConfig } from '../types/intercom-config';
 import { loadIntercom } from '../util/load-intercom';
+
+
+export const CONFIG = new InjectionToken('CONFIG');
 
 /**
  * @description A provider with every Intercom.JS method


### PR DESCRIPTION
As described in #14, the current version leads to an error while initializing the `IntercomModule` due to a circular dependency in the libraries imports. Moving die `CONFIG` token from the intercom.module.ts to the intercom.ts fixes this issue.