### PR TITLE
Optionally load the config via forRoot

### DIFF
--- a/src/app/ng-intercom/intercom.module.ts
+++ b/src/app/ng-intercom/intercom.module.ts
@@ -35,7 +35,7 @@ import { IntercomConfig } from './shared/intercom-config'
   ]
 })
 export class IntercomModule {
-  static forRoot(config: IntercomConfig): ModuleWithProviders {
+  static forRoot(config?: IntercomConfig): ModuleWithProviders {
     return {
       ngModule: IntercomModule,
       providers: [

--- a/src/app/ng-intercom/intercom/intercom.ts
+++ b/src/app/ng-intercom/intercom/intercom.ts
@@ -12,10 +12,11 @@ import { Any, BootInput } from '../types/boot-input'
 export class Intercom {
 
   private id: string
+  private config: IntercomConfig;
 
   constructor(
     @Inject(PLATFORM_ID) protected platformId: Object,
-    @Optional() @Inject(IntercomConfig) private config: IntercomConfig,
+    @Optional() @Inject(IntercomConfig) config: IntercomConfig,
     @Optional() @Inject(Router) private router: Router
   ) {
     if (!isPlatformBrowser(this.platformId)) {
@@ -235,6 +236,8 @@ export class Intercom {
     // if (!isPlatformBrowser(this.platformId)) {
     //   return
     // }
+
+    this.config = config
 
     this.id = config.appId
     const w = <any>window

--- a/src/app/ng-intercom/intercom/intercom.ts
+++ b/src/app/ng-intercom/intercom/intercom.ts
@@ -22,21 +22,26 @@ export class Intercom {
       return
     }
 
-    // Run load and attacht to window
-    this.loadIntercom(config)
+    if (config) {
+      if (!config.delayLoad) {
+        // Run load and attacht to window
+        this.loadIntercom(config)
+      }
 
-    // Subscribe to router changes
-    if (config && config.updateOnRouterChange) {
-      this.router.events.subscribe(event => {
-        this.update()
-      })
-    }
-    else if (isDevMode()) {
-      console.warn(`
+      // Subscribe to router changes
+      if (config.updateOnRouterChange) {
+        this.router.events.subscribe(event => {
+          this.update()
+        })
+      }
+
+      else if (isDevMode()) {
+        console.warn(`
       Common practice in single page applications is to update whenever the route changes.
       ng-intercom supports this functionality out of the box just set 'updateOnRouterChange' to true in your Intercom Module config.
        This warning will not appear in production, if you choose not to use router updating.
      `)
+      }
     }
   }
 

--- a/src/app/ng-intercom/intercom/intercom.ts
+++ b/src/app/ng-intercom/intercom/intercom.ts
@@ -14,8 +14,8 @@ export class Intercom {
   private id: string
 
   constructor(
-    @Inject(IntercomConfig) private config: IntercomConfig,
     @Inject(PLATFORM_ID) protected platformId: Object,
+    @Optional() @Inject(IntercomConfig) private config: IntercomConfig,
     @Optional() @Inject(Router) private router: Router
   ) {
     if (!isPlatformBrowser(this.platformId)) {
@@ -23,25 +23,8 @@ export class Intercom {
     }
 
     if (config) {
-      if (!config.delayLoad) {
-        // Run load and attacht to window
-        this.loadIntercom(config)
-      }
-
-      // Subscribe to router changes
-      if (config.updateOnRouterChange) {
-        this.router.events.subscribe(event => {
-          this.update()
-        })
-      }
-
-      else if (isDevMode()) {
-        console.warn(`
-      Common practice in single page applications is to update whenever the route changes.
-      ng-intercom supports this functionality out of the box just set 'updateOnRouterChange' to true in your Intercom Module config.
-       This warning will not appear in production, if you choose not to use router updating.
-     `)
-      }
+      // Run load and attacht to window
+      this.loadIntercom(config)
     }
   }
 
@@ -273,6 +256,21 @@ export class Intercom {
       } else {
         w.addEventListener('load', this.l, false)
       }
+    }
+
+    // Subscribe to router changes
+    if (config.updateOnRouterChange) {
+      this.router.events.subscribe(event => {
+        this.update()
+      })
+    }
+
+    else if (isDevMode()) {
+      console.warn(`
+      Common practice in single page applications is to update whenever the route changes.
+      ng-intercom supports this functionality out of the box just set 'updateOnRouterChange' to true in your Intercom Module config.
+       This warning will not appear in production, if you choose not to use router updating.
+     `)
     }
   }
 }

--- a/src/app/ng-intercom/intercom/intercom.ts
+++ b/src/app/ng-intercom/intercom/intercom.ts
@@ -217,20 +217,6 @@ export class Intercom {
     return (<any>window).Intercom('onUnreadCountChange', handler)
   }
 
-  l(): void {
-    // if (!isPlatformBrowser(this.platformId)) {
-    //   return
-    // }
-
-    const d = document
-    const s = d.createElement('script')
-    s.type = 'text/javascript'
-    s.async = true
-    s.src = `https://widget.intercom.io/widget/${this.id}`
-    const x = d.getElementsByTagName('script')[0]
-    x.parentNode.insertBefore(s, x)
-  }
-
   loadIntercom(config: IntercomConfig): void {
     // if (!isPlatformBrowser(this.platformId)) {
     //   return
@@ -251,11 +237,13 @@ export class Intercom {
         i.q.push(args)
       }
       w.Intercom = i
-      if (w.attachEvent) {
-        w.attachEvent('onload', this.l.bind(this))
-      } else {
-        w.addEventListener('load', this.l.bind(this), false)
-      }
+      const d = document
+      const s = d.createElement('script')
+      s.type = 'text/javascript'
+      s.async = true
+      s.src = `https://widget.intercom.io/widget/${this.id}`
+      const x = d.getElementsByTagName('script')[0]
+      x.parentNode.insertBefore(s, x)
     }
 
     // Subscribe to router changes

--- a/src/app/ng-intercom/intercom/intercom.ts
+++ b/src/app/ng-intercom/intercom/intercom.ts
@@ -12,7 +12,6 @@ import { Any, BootInput } from '../types/boot-input'
 export class Intercom {
 
   private id: string
-  private config: IntercomConfig;
 
   constructor(
     @Inject(PLATFORM_ID) protected platformId: Object,
@@ -41,7 +40,7 @@ export class Intercom {
 
     const data = {
       ...intercomData,
-      app_id: this.config.appId
+      app_id: this.id,
     }
 
     return (<any>window).Intercom('boot', data)
@@ -237,8 +236,6 @@ export class Intercom {
     //   return
     // }
 
-    this.config = config
-
     this.id = config.appId
     const w = <any>window
     const ic = w.Intercom
@@ -255,9 +252,9 @@ export class Intercom {
       }
       w.Intercom = i
       if (w.attachEvent) {
-        w.attachEvent('onload', this.l)
+        w.attachEvent('onload', this.l.bind(this))
       } else {
-        w.addEventListener('load', this.l, false)
+        w.addEventListener('load', this.l.bind(this), false)
       }
     }
 

--- a/src/app/ng-intercom/shared/intercom-config.ts
+++ b/src/app/ng-intercom/shared/intercom-config.ts
@@ -1,24 +1,4 @@
 export class IntercomConfig {
-  delayLoad = false
   appId?: string
   updateOnRouterChange?: boolean
-
-  constructor()
-  constructor(appId: string, updateOnRouterChange?: boolean)
-  constructor(...params: any[]) {
-    switch (params.length) {
-      case 0:
-        this.delayLoad = true
-        break
-
-      case 1:
-        this.appId = params[0]
-        break
-
-      case 2:
-        this.appId = params[0];
-        this.updateOnRouterChange = Boolean(params[1])
-        break
-    }
-  }
 }

--- a/src/app/ng-intercom/shared/intercom-config.ts
+++ b/src/app/ng-intercom/shared/intercom-config.ts
@@ -1,4 +1,4 @@
 export class IntercomConfig {
-  appId?: string
+  appId: string
   updateOnRouterChange?: boolean
 }

--- a/src/app/ng-intercom/shared/intercom-config.ts
+++ b/src/app/ng-intercom/shared/intercom-config.ts
@@ -1,4 +1,24 @@
 export class IntercomConfig {
-  appId: string
+  delayLoad = false
+  appId?: string
   updateOnRouterChange?: boolean
+
+  constructor()
+  constructor(appId: string, updateOnRouterChange?: boolean)
+  constructor(...params: any[]) {
+    switch (params.length) {
+      case 0:
+        this.delayLoad = true
+        break
+
+      case 1:
+        this.appId = params[0]
+        break
+
+      case 2:
+        this.appId = params[0];
+        this.updateOnRouterChange = Boolean(params[1])
+        break
+    }
+  }
 }


### PR DESCRIPTION
Currently `IntercomModule.forRoot` forces you to provide the config when loading the module. This prevents config from being provided asynchronous.

This PR makes it optional to provide the config initially via `IntercomModule.forRoot`. The function `Intercom.loadIntercom` can then be called at a later point.

This fixes #28 