### PR TITLE
(fix): allow app_id to be passed into Boot (fixes #72)

### DIFF
--- a/src/app/ng-intercom-testing/intercom-mocks.ts
+++ b/src/app/ng-intercom-testing/intercom-mocks.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router'
 import { isPlatformBrowser } from '@angular/common'
 
 import { IntercomConfig } from '../ng-intercom/shared/intercom-config'
-import { Any, BootInput } from '../ng-intercom/types/boot-input'
+import {  BootInput } from '../ng-intercom/types/boot-input'
 import { Intercom } from '../ng-intercom/intercom/intercom'
 
 /**
@@ -61,7 +61,7 @@ export class IntercomMocks extends Intercom {
      * Calling the update method with a JSON object of user details will update those fields on the current user
      * in addition to logging an impression at the current URL and looking for new messages for the user.
      */
-    public update(data?: Any): void {
+    public update(data?: any): void {
         return
     }
 

--- a/src/app/ng-intercom/intercom/intercom.ts
+++ b/src/app/ng-intercom/intercom/intercom.ts
@@ -59,13 +59,13 @@ export class Intercom {
     if (!isPlatformBrowser(this.platformId)) {
       return
     }
-
+    const app_id = intercomData.app_id ? intercomData.app_id : this.config.appId
     // Run load and attach to window
     this.loadIntercom(this.config, (event?: Event) => {
       // then boot the intercom js
       const data = {
         ...intercomData,
-        app_id: this.config.appId
+        app_id
       }
 
       return this.callIntercom('boot', data)

--- a/src/app/ng-intercom/intercom/intercom.ts
+++ b/src/app/ng-intercom/intercom/intercom.ts
@@ -4,7 +4,7 @@ import { Router } from '@angular/router'
 import { isPlatformBrowser } from '@angular/common'
 
 import { IntercomConfig } from '../shared/intercom-config'
-import { Any, BootInput } from '../types/boot-input'
+import { BootInput } from '../types/boot-input'
 
 /**
  * A provider with every Intercom.JS method
@@ -95,7 +95,7 @@ export class Intercom {
    * Calling the update method with a JSON object of user details will update those fields on the current user
    * in addition to logging an impression at the current URL and looking for new messages for the user.
    */
-  public update(data?: Any): void {
+  public update(data?: any): void {
     if (!isPlatformBrowser(this.platformId)) {
       return
     }

--- a/src/app/ng-intercom/types/boot-input.ts
+++ b/src/app/ng-intercom/types/boot-input.ts
@@ -1,18 +1,10 @@
-export interface UserWithEmail {
-    email?: string;
-}
-
-export interface UserWithUid {
+export interface BootInput {
+    custom_launcher_selector?: string;
     user_id?: string;
-}
-
-export interface Any {
+    email?: string;
+    /**
+     * If no app_id is passed, the value on config will be used
+     */
+    app_id?: string;
     [propName: string]: any;
 }
-
-export interface DefaultBootInput {
-    custom_launcher_selector?: string;
-}
-
-export type BootInput = ((UserWithEmail | UserWithUid) & DefaultBootInput & Any) | DefaultBootInput
-


### PR DESCRIPTION
<!-- Thank you for contributing to NgIntercom! Before we begin, let's make sure some stuff is in order. Please check the boxes below with an 'X' after each item is met. -->

Summary of changes: 

Intended/example use case: 

Checklist:
- [ ] `npm run build` runs without error
- [ ] `ng serve` spawns app, Intercom messenger is visible and interactive, and there are no errors in the console

Closes issue: #

<!-- thanks for your contribution! -->
