### PR TITLE
make trackEvent take any metadata, fixes #77

### DIFF
--- a/ng-package.json
+++ b/ng-package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
   "name": "ng-intercom",
-  "version": "6.0.0-beta.6",
+  "version": "6.0.0-beta.7",
   "licensePath": "LICENSE",
   "lib": {
     "entryFile": "public_api.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-intercom",
-  "version": "6.0.0-beta.6",
+  "version": "6.0.0-beta.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-intercom",
-  "version": "6.0.0-beta.6",
+  "version": "6.0.0-beta.7",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/app/ng-intercom/intercom/intercom.ts
+++ b/src/app/ng-intercom/intercom/intercom.ts
@@ -165,7 +165,7 @@ export class Intercom {
    *
    * You can also add custom information to events in the form of event metadata.
    */
-  public trackEvent(eventName: string, metadata?: string): void {
+  public trackEvent(eventName: string, metadata?: any): void {
     if (!isPlatformBrowser(this.platformId)) {
       return
     }


### PR DESCRIPTION
<!-- Thank you for contributing to NgIntercom! Before we begin, let's make sure some stuff is in order. Please check the boxes below with an 'X' after each item is met. -->

Summary of changes: 

Intended/example use case: 

Checklist:
- [ ] `npm run build` runs without error
- [ ] `ng serve` spawns app, Intercom messenger is visible and interactive, and there are no errors in the console

Closes issue: #

<!-- thanks for your contribution! -->
