### PR TITLE
[fix] #87 #51

### DIFF
--- a/ng-package.json
+++ b/ng-package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
   "name": "ng-intercom",
-  "version": "7.0.1-beta.1",
+  "version": "7.0.1-beta.2",
   "licensePath": "LICENSE",
   "lib": {
     "entryFile": "public_api.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-intercom",
-  "version": "7.0.1-beta.1",
+  "version": "7.0.1-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-intercom",
-  "version": "7.0.1-beta.1",
+  "version": "7.0.1-beta.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/app/ng-intercom/intercom/intercom.ts
+++ b/src/app/ng-intercom/intercom/intercom.ts
@@ -56,6 +56,7 @@ export class Intercom {
    * when the page loads. You call this method with the standard intercomSettings object.
    */
   public boot(intercomData?: BootInput): void {
+    console.log('brk', intercomData)
     if (!isPlatformBrowser(this.platformId)) {
       return
     }
@@ -241,6 +242,10 @@ export class Intercom {
       return
     }
 
+    // Set the window configuration to conf
+    (<any>window).intercomSettings = conf
+
+    // Create the intercom script in document
     const s = this.document.createElement('script')
     s.type = 'text/javascript'
     s.async = true
@@ -267,6 +272,10 @@ export class Intercom {
     this.id = config.appId
     const w = <any>window
     const ic = w.Intercom
+
+    // Set window config for Intercom
+    w.intercomSettings = config
+
     if (typeof ic === 'function') {
       ic('reattach_activator')
       ic('update', config)

--- a/src/app/ng-intercom/shared/intercom-config.ts
+++ b/src/app/ng-intercom/shared/intercom-config.ts
@@ -4,5 +4,22 @@ import { Injectable } from '@angular/core'
 export class IntercomConfig {
   appId: string
   updateOnRouterChange?: boolean
+  /**
+   * Customize left or right position of messenger
+   */
   alignment?: 'left' | 'right'
+  /**
+   * Customize horizontal padding
+   */
+  horizontal_padding?: number
+
+  /**
+   * Customize vertical padding
+   */
+  vertical_padding?: number
+
+  /**
+   * arbitrarily localize your intercom messenger
+   */
+  language_override?: string
 }

--- a/src/app/root/app.component.ts
+++ b/src/app/root/app.component.ts
@@ -31,6 +31,7 @@ export class AppComponent implements OnInit {
     this.intercom.boot({
       app_id: 'klwzj86j',
       // Supports all optional configuration.
+      alignment: 'right',
       widget: {
         'activator': '#intercom'
       }
@@ -41,6 +42,7 @@ export class AppComponent implements OnInit {
       setTimeout(() => this.intercom.boot({
         app_id: 'klwzj86j',
         // Supports all optional configuration.
+        alignment: 'left',
         widget: {
           'activator': '#intercom'
         }

--- a/src/app/root/app.module.ts
+++ b/src/app/root/app.module.ts
@@ -36,7 +36,8 @@ import { IntercomModule } from '../ng-intercom/intercom.module'
     SharedModule,
     IntercomModule.forRoot({
       appId: 'klwzj86j',
-      updateOnRouterChange: true
+      updateOnRouterChange: true,
+      alignment: 'left'
     }),
     environment.production ? ServiceWorkerModule.register('/ngsw-worker.js') : []
   ],

--- a/src/app/root/app.server.module.ts
+++ b/src/app/root/app.server.module.ts
@@ -28,7 +28,8 @@ import { IntercomModule } from '../ng-intercom/intercom.module'
     SharedModule,
     IntercomModule.forRoot({
       appId: 'klwzj86j',
-      updateOnRouterChange: true
+      updateOnRouterChange: true,
+      alignment: 'left'
     })
   ],
   providers: [],


### PR DESCRIPTION
#### Summary of changes: 
Set's a window intercomSettings variable before boot and script attach.  This allows for the widget to correctly inherit the configuration.

#### Intended/example use case: 
Align, pad, margin of intercom widget

Checklist:
- [x] `npm run build` runs without error
- [x] `ng serve` spawns app, Intercom messenger is visible and interactive, and there are no errors in the console

Closes issue: #87, #51 
