### PR TITLE
Fix DOCUMENT import, removed from platform-browser in Angular 8

### DIFF
--- a/src/app/ng-intercom/intercom/intercom.ts
+++ b/src/app/ng-intercom/intercom/intercom.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable, PLATFORM_ID, Optional, isDevMode, Renderer2, RendererFactory2, ViewEncapsulation } from '@angular/core'
-import { DOCUMENT } from '@angular/platform-browser'
 import { Router } from '@angular/router'
-import { isPlatformBrowser } from '@angular/common'
+import { DOCUMENT, isPlatformBrowser } from '@angular/common'
 
 import { IntercomConfig } from '../shared/intercom-config'
 import { BootInput } from '../types/boot-input'


### PR DESCRIPTION
Summary of changes: Fix `DOCUMENT` import, removed from `@angular-platform-browser` in 8.0.0-rc.0

Intended/example use case: The lib does not run.

Checklist:
- [x] `npm run build` runs without error
- [x] `ng serve` spawns app, Intercom messenger is visible and interactive, and there are no errors in the console

Closes issue: #92 