### PR TITLE
Fix issue with routing performance when using updateOnRouterChange

### DIFF
--- a/src/app/ng-intercom/intercom/intercom.ts
+++ b/src/app/ng-intercom/intercom/intercom.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, PLATFORM_ID, Optional, isDevMode, Renderer2, RendererFactory2, ViewEncapsulation } from '@angular/core'
-import { Router } from '@angular/router'
+import { filter } from 'rxjs/internal/operators/filter'
+import { Router, NavigationEnd } from '@angular/router'
 import { DOCUMENT, isPlatformBrowser } from '@angular/common'
 
 import { IntercomConfig } from '../shared/intercom-config'
@@ -36,7 +37,7 @@ export class Intercom {
 
     // Subscribe to router changes
     if (config && config.updateOnRouterChange) {
-      this.router.events.subscribe(event => {
+      this.router.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(event => {
         this.update()
       })
     }

--- a/src/app/ng-intercom/intercom/intercom.ts
+++ b/src/app/ng-intercom/intercom/intercom.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, PLATFORM_ID, Optional, isDevMode, Renderer2, RendererFactory2, ViewEncapsulation } from '@angular/core'
-import { filter } from 'rxjs/internal/operators/filter'
+import { filter } from 'rxjs/operators'
 import { Router, NavigationEnd } from '@angular/router'
 import { DOCUMENT, isPlatformBrowser } from '@angular/common'
 


### PR DESCRIPTION
Fix for #97

<!-- Thank you for contributing to NgIntercom! Before we begin, let's make sure some stuff is in order. Please check the boxes below with an 'X' after each item is met. -->

Summary of changes: 

Intended/example use case: 

When using `updateOnRouterChange` the update would fire multiple times per route change causing performance problems. With this change the update will fire only once after a successful navigation.

Checklist:
- [x] `npm run build` runs without error
- [x] `ng serve` spawns app, Intercom messenger is visible and interactive, and there are no errors in the console

Closes issue: #

<!-- thanks for your contribution! -->
