### PR TITLE
Add missing generic type for Angular 9

### DIFF
--- a/src/app/ng-intercom/intercom.module.ts
+++ b/src/app/ng-intercom/intercom.module.ts
@@ -36,7 +36,7 @@ import { IntercomConfig } from './shared/intercom-config'
   ]
 })
 export class IntercomModule {
-  static forRoot(config: IntercomConfig): ModuleWithProviders {
+  static forRoot(config: IntercomConfig): ModuleWithProviders<IntercomModule> {
     return {
       ngModule: IntercomModule,
       providers: [


### PR DESCRIPTION
<!-- Thank you for contributing to NgIntercom! Before we begin, let's make sure some stuff is in order. Please check the boxes below with an 'X' after each item is met. -->

Summary of changes: 
Added the generic type in module declaration to support Angular 9.

Checklist:
- [X ] `npm run build` runs without error
- [X ] `ng serve` spawns app, Intercom messenger is visible and interactive, and there are no errors in the console

Closes issue: #101

<!-- thanks for your contribution! -->
