### PR TITLE
Fix boot() without params

### DIFF
--- a/src/app/ng-intercom/intercom/intercom.ts
+++ b/src/app/ng-intercom/intercom/intercom.ts
@@ -59,7 +59,7 @@ export class Intercom {
     if (!isPlatformBrowser(this.platformId)) {
       return
     }
-    const app_id = intercomData.app_id ? intercomData.app_id : this.config.appId
+    const app_id = intercomData && intercomData.app_id ? intercomData.app_id : this.config.appId
     // Run load and attach to window
     this.loadIntercom(this.config, (event?: Event) => {
       // then boot the intercom js


### PR DESCRIPTION
<!-- Thank you for contributing to NgIntercom! Before we begin, let's make sure some stuff is in order. Please check the boxes below with an 'X' after each item is met. -->

Summary of changes: The `boot()` method has 1 optional parameter (`intercomData`) but when called without any param, it will throw an error because we are checking `app_id` inside `intercomData` directly without checking the `intercomData` itself

Intended/example use case: Call `.boot()` method without any param will cause an error


Checklist:
- [x] `npm run build` runs without error
- [x] `ng serve` spawns app, Intercom messenger is visible and interactive, and there are no errors in the console

Closes issue: #

<!-- thanks for your contribution! -->
