### PR TITLE
fix(intercom): safely check for app_id in optional param

### DIFF
--- a/src/app/ng-intercom/intercom/intercom.ts
+++ b/src/app/ng-intercom/intercom/intercom.ts
@@ -59,7 +59,7 @@ export class Intercom {
     if (!isPlatformBrowser(this.platformId)) {
       return
     }
-    const app_id = intercomData.app_id ? intercomData.app_id : this.config.appId
+    const app_id = intercomData?.app_id ? intercomData.app_id : this.config.appId
     // Run load and attach to window
     this.loadIntercom(this.config, (event?: Event) => {
       // then boot the intercom js
@@ -187,11 +187,11 @@ export class Intercom {
   }
 
   /**
-   * If you would like to trigger a tour based on an action a user or visitor takes in your site or application, 
-   * ou can use this API method. You need to call this method with the id of the tour you wish to show. The id of 
+   * If you would like to trigger a tour based on an action a user or visitor takes in your site or application,
+   * ou can use this API method. You need to call this method with the id of the tour you wish to show. The id of
    * the tour can be found in the “Use tour everywhere” section of the tour editor.
    *
-   * Please note that tours shown via this API must be published and the “Use tour everywhere” section must be 
+   * Please note that tours shown via this API must be published and the “Use tour everywhere” section must be
    * turned on. If you're calling this API using an invalid tour id, nothing will happen.
    */
   public startTour(tourId: number): void {


### PR DESCRIPTION
<!-- Thank you for contributing to NgIntercom! Before we begin, let's make sure some stuff is in order. Please check the boxes below with an 'X' after each item is met. -->

Summary of changes: 
Because `intercomData` is optional in the `boot` method then we need to use optional chaining to check for `app_id` otherwise it will error if that parameter is not passed on

Intended/example use case: 
`app_id` is configured in the `forRoot` method so when calling `.boot()` without a paramter the line `const app_id = intercomData.app_id ? intercomData.app_id : this.config.appId` will error since `intercomData` is optional.

Checklist:
- [x] `npm run build` runs without error
- [x] `ng serve` spawns app, Intercom messenger is visible and interactive, and there are no errors in the console

Closes issue: #

<!-- thanks for your contribution! -->
